### PR TITLE
Allow optional 24th word input

### DIFF
--- a/browserify.sh
+++ b/browserify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-browserify \
+npx browserify \
 	-r bip32 \
 	-r bip39 \
 	-r jquery \

--- a/calculator/last-word.html
+++ b/calculator/last-word.html
@@ -151,6 +151,18 @@
               </div>
             </div>
           </div>
+          <div class="field is-pulled-right">
+            <p class="is-size-7">
+              <label
+                >Allow 24th word as partial input (advanced).</label
+              >
+              <input
+                id="allow_24th_word_input"
+                class="checkbox"
+                type="checkbox"
+              />
+            </p>
+          </div>
         </div>
         <div id="results" class="tighter_section is-hidden">
           <div>

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -78,7 +78,7 @@ function rootFingerPrintFromMnemonic(mnemonic) {
     return fingerprint;
 }
 
-function validate(suppliedSeedPhrase) {
+function validate(suppliedSeedPhrase, allow24thWord) {
     let wordCount = 0
     const trimmedWords = suppliedSeedPhrase
         .trim()
@@ -90,7 +90,7 @@ function validate(suppliedSeedPhrase) {
     if (trimmedWords.length > 0) {
         wordCount = trimmedWords.length
     }
-    if (wordCount !== 23) {
+    if (wordCount !== 23 && !(allow24thWord && wordCount === 24)) {
         const msg = "Please enter 23 words. (You entered " + wordCount + ")"
         return validationReply(msg)
     }
@@ -112,12 +112,22 @@ function validationReply(errorMsg, words) {
     return {
         valid: errorMsg === "",
         errorMessage: errorMsg,
-        cleanedUpPhrase: words
+        cleanedUpPhrase: words && words.split(" ")
     }
 }
 
 function firstChecksumWordAlphabetically(suppliedSeedPhrase) {
-    return allChecksumWords(suppliedSeedPhrase)[0]
+    const dictionary = bip39.wordlists[bip39.getDefaultWordlist()]
+    const bits = suppliedSeedPhrase
+        .map(word => dictionary.indexOf(word).toString(2).padStart(11, 0))
+        .join("")
+        .slice(0, 256)
+        .padEnd(256, "0")
+    const hex = bits.match(/..../g)
+        .map(b => parseInt(b, 2).toString(16))
+        .join("")
+    const mnemonic = bip39.entropyToMnemonic(hex)
+    return mnemonic.split(" ")[23]
 }
 
 function allChecksumWords(suppliedSeedPhrase) {

--- a/lib/presentation.js
+++ b/lib/presentation.js
@@ -98,7 +98,9 @@ function scrollTo(selector) {
 
 function submitButtonAction(callback) {
     const phraseField = $("#seedphrase_input");
-    const validation = logic.validate(phraseField.val())
+    const allow24thWord = $("#allow_24th_word_input");
+    const validation =
+        logic.validate(phraseField.val(), allow24thWord.is(':checked'));
     const $seedErrorMsg = $("#seed_error_msg");
     $("#results").addClass('is-hidden');
     hideAdvanced()
@@ -109,14 +111,14 @@ function submitButtonAction(callback) {
         return
     }
     $seedErrorMsg.addClass('is-hidden');
-    phraseField.text(validation.cleanedUpPhrase)
+    phraseField.text(validation.cleanedUpPhrase.join(" "))
 
     const $seedButton = $("#seed-submit");
     $seedButton.addClass("is-loading")
 
     setTimeout(() => {
         const checksumWord = logic.firstChecksumWordAlphabetically(validation.cleanedUpPhrase)
-        const mnemonic = validation.cleanedUpPhrase + " " + checksumWord
+        const mnemonic = [...validation.cleanedUpPhrase.slice(0, 23), checksumWord].join(" ")
         const pubKeys = logic.keysFromMnemonic(mnemonic, network);
         const rootFingerprint = logic.rootFingerPrintFromMnemonic(mnemonic)
         const fileExportData = logic.assembleExportFileData(rootFingerprint, pubKeys)

--- a/test/logic.test.js
+++ b/test/logic.test.js
@@ -20,7 +20,12 @@ describe("Calculate the 24th word", function () {
 
     //https://github.com/merland/seedpicker/issues/13
     it("should select the first checksum word, alphabetically", () => {
-        const my23words = "empower soul reunion entire help raise truth reflect argue transfer chicken narrow oak friend junior figure auto small push spike next pledge december"
+        const my23words = [
+          "empower", "soul", "reunion", "entire", "help", "raise", "truth",
+          "reflect", "argue", "transfer", "chicken", "narrow", "oak", "friend",
+          "junior", "figure", "auto", "small", "push", "spike", "next",
+          "pledge", "december"
+        ]
         const lastWord = logic.firstChecksumWordAlphabetically(my23words);
 
         const expectedWords = ["bridge"]

--- a/test/logic.test.js
+++ b/test/logic.test.js
@@ -31,6 +31,18 @@ describe("Calculate the 24th word", function () {
         const expectedWords = ["bridge"]
         expect(lastWord).to.be.oneOf(expectedWords);
     })
+    it("should correct the checksum word", () => {
+        const my24words = [
+          "empower", "soul", "reunion", "entire", "help", "raise", "truth",
+          "reflect", "argue", "transfer", "chicken", "narrow", "oak", "friend",
+          "junior", "figure", "auto", "small", "push", "spike", "next",
+          "pledge", "december", "zoo"
+        ]
+        const lastWord = logic.firstChecksumWordAlphabetically(my24words);
+
+        const expectedWords = ["wedding"]
+        expect(lastWord).to.be.oneOf(expectedWords);
+    })
     it('should have an empty error message if supplied words are valid', function () {
         const result = logic.validate("empower soul reunion entire help raise truth reflect argue transfer chicken narrow oak friend junior figure auto small push spike next pledge december");
         expect(result.errorMessage).to.be.empty


### PR DESCRIPTION
Currently, SeedPicker requires exactly 23 words as input, from which the 24th word is calculated. This affords 253 bits of entropy (23 x 11 = 253).

This pull request introduces a checkbox to allow the user to supply a 24th word as input. When supplied, the 24th word contributes 3 bits to the overall entropy.

As a part of this change, the logic function `firstChecksumWordAlphabetically()` no longer calls through to `allChecksumWords()`. I believe the latter to be unnecessary, as computing the checksum is a deterministic operation.

This pull request builds on and includes the changes in PR #42.